### PR TITLE
 EXEEXT Fixes

### DIFF
--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -3,7 +3,7 @@ include $(top_srcdir)/test/Makefile.inc
 AM_CFLAGS += -I$(srcdir)/common
 AM_LDFLAGS += -static
 
-TESTS_ENVIRONMENT = ODP_PLATFORM=${with_platform} TEST_DIR=${builddir}
+TESTS_ENVIRONMENT += TEST_DIR=${builddir}
 
 EXECUTABLES = odp_chksum$(EXEEXT) \
               odp_thread$(EXEEXT) \

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -7,7 +7,7 @@ TESTS = pktio/pktio_run \
 	${top_builddir}/test/validation/buffer/buffer_main$(EXEEXT) \
 	${top_builddir}/test/validation/classification/classification_main$(EXEEXT) \
 	${top_builddir}/test/validation/cpumask/cpumask_main$(EXEEXT) \
-	${top_builddir}/test/validation/crypto/crypto_main \
+	${top_builddir}/test/validation/crypto/crypto_main$(EXEEXT) \
 	${top_builddir}/test/validation/errno/errno_main$(EXEEXT) \
 	${top_builddir}/test/validation/init/init_main_ok$(EXEEXT) \
 	${top_builddir}/test/validation/init/init_main_abort$(EXEEXT) \

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -1,4 +1,5 @@
-TESTS_ENVIRONMENT = TEST_DIR=${top_builddir}/test/validation
+include $(top_srcdir)/test/Makefile.inc
+TESTS_ENVIRONMENT += TEST_DIR=${top_builddir}/test/validation
 
 ODP_MODULES = pktio
 

--- a/platform/linux-generic/test/pktio/pktio_run
+++ b/platform/linux-generic/test/pktio/pktio_run
@@ -17,7 +17,7 @@ PATH=$(dirname $0):$PATH
 PATH=$(dirname $0)/../../../../test/validation/pktio:$PATH
 PATH=.:$PATH
 
-pktio_main_path=$(which pktio_main)
+pktio_main_path=$(which pktio_main${EXEEXT})
 if [ -x "$pktio_main_path" ] ; then
 	echo "running with pktio_main: $pktio_run_path"
 else
@@ -57,7 +57,7 @@ run_test()
 		if [ "$disabletype" != "SKIP" ]; then
 			export ODP_PKTIO_DISABLE_SOCKET_${distype}=y
 		fi
-		pktio_main
+		pktio_main${EXEEXT}
 		if [ $? -ne 0 ]; then
 			ret=1
 		fi
@@ -75,7 +75,7 @@ run()
 	#need to be root to set the interface: if not, run with default loopback.
 	if [ "$(id -u)" != "0" ]; then
 		echo "pktio: using 'loop' device"
-		pktio_main
+		pktio_main${EXEEXT}
 		exit $?
 	fi
 

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -20,3 +20,5 @@ AM_LDFLAGS += -L$(LIB)
 
 @VALGRIND_CHECK_RULES@
 valgrind_tools = memcheck drd sgcheck
+
+TESTS_ENVIRONMENT= ODP_PLATFORM=${with_platform}

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -21,4 +21,4 @@ AM_LDFLAGS += -L$(LIB)
 @VALGRIND_CHECK_RULES@
 valgrind_tools = memcheck drd sgcheck
 
-TESTS_ENVIRONMENT= ODP_PLATFORM=${with_platform}
+TESTS_ENVIRONMENT= ODP_PLATFORM=${with_platform} EXEEXT=${EXEEXT}

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/test/Makefile.inc
 
-TESTS_ENVIRONMENT = TEST_DIR=${builddir} ODP_PLATFORM=${with_platform}
+TESTS_ENVIRONMENT += TEST_DIR=${builddir}
 
 EXECUTABLES = odp_atomic$(EXEEXT) odp_pktio_perf$(EXEEXT)
 

--- a/test/performance/odp_l2fwd_run
+++ b/test/performance/odp_l2fwd_run
@@ -56,12 +56,12 @@ run_l2fwd()
 
 	#@todo: limit odp_generator to cores
 	#https://bugs.linaro.org/show_bug.cgi?id=1398
-	(odp_generator -I $IF0 \
+	(odp_generator${EXEEXT} -I $IF0 \
 			--srcip 192.168.0.1 --dstip 192.168.0.2 -m u 2>&1 > /dev/null) \
 			2>&1 > /dev/null &
 
 	echo "Run odp_l2fwd -i $IF1,$IF2 -m 0 -t 30 -c 2"
-	odp_l2fwd -i $IF1,$IF2 -m 0 -t 30 -c 2
+	odp_l2fwd${EXEEXT} -i $IF1,$IF2 -m 0 -t 30 -c 2
 
 	cleanup_pktio_env
 	if [ $? -ne 0 ]; then

--- a/test/performance/odp_scheduling_run
+++ b/test/performance/odp_scheduling_run
@@ -16,7 +16,7 @@ run()
 	echo odp_scheduling_run starts with $1 worker threads
 	echo ===============================================
 
-	$TEST_DIR/odp_scheduling -c $1 || ret=1
+	$TEST_DIR/odp_scheduling${EXEEXT} -c $1 || ret=1
 }
 
 run 1

--- a/test/validation/common/Makefile.am
+++ b/test/validation/common/Makefile.am
@@ -1,10 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 include $(top_srcdir)/test/Makefile.inc
 
-#libcunit_common_as_main.a is meant to be removed when all tests define
-#their own main
-noinst_LIBRARIES = libcunit_common.a libcunit_common_as_main.a
-libcunit_common_a_CFLAGS = $(AM_CFLAGS) -DMODULE_HAS_OWN_MAIN
+noinst_LIBRARIES = libcunit_common.a
+libcunit_common_a_CFLAGS = $(AM_CFLAGS)
 libcunit_common_a_SOURCES = odp_cunit_common.c
-libcunit_common_as_main_a_CFLAGS = $(AM_CFLAGS)
-libcunit_common_as_main_a_SOURCES = odp_cunit_common.c

--- a/test/validation/common/odp_cunit_common.c
+++ b/test/validation/common/odp_cunit_common.c
@@ -121,11 +121,3 @@ int odp_cunit_run(CU_SuiteInfo testsuites[])
 
 	return (ret) ? -1 : 0;
 }
-
-/* this is left for old style main declartion. will be removed soon */
-#ifndef MODULE_HAS_OWN_MAIN
-int main(void)
-{
-	return odp_cunit_run(odp_testsuites);
-}
-#endif

--- a/test/validation/common/odp_cunit_common.c
+++ b/test/validation/common/odp_cunit_common.c
@@ -15,6 +15,8 @@ static odph_linux_pthread_t thread_tbl[MAX_WORKERS];
  * global init/term functions which may be registered
  * defaults to functions performing odp init/term.
  */
+static int tests_global_init(void);
+static int tests_global_term(void);
 static struct {
 	int (*global_init_ptr)(void);
 	int (*global_term_ptr)(void);
@@ -42,7 +44,7 @@ int odp_cunit_thread_exit(pthrd_arg *arg)
 	return 0;
 }
 
-ODP_WEAK_SYMBOL int tests_global_init(void)
+static int tests_global_init(void)
 {
 	if (0 != odp_init_global(NULL, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
@@ -56,7 +58,7 @@ ODP_WEAK_SYMBOL int tests_global_init(void)
 	return 0;
 }
 
-ODP_WEAK_SYMBOL int tests_global_term(void)
+static int tests_global_term(void)
 {
 	if (0 != odp_term_local()) {
 		fprintf(stderr, "error: odp_term_local() failed.\n");
@@ -76,8 +78,6 @@ ODP_WEAK_SYMBOL int tests_global_term(void)
  * If some of these functions are not registered, the defaults functions
  * (tests_global_init() and tests_global_term()) defined above are used.
  * One should use these register functions when defining these hooks.
- * (overloading the weak symbol above is obsolete and will be removed in
- * the future).
  * Note that passing NULL as function pointer is valid and will simply
  * prevent the default (odp init/term) to be done.
  */

--- a/test/validation/common/odp_cunit_common.h
+++ b/test/validation/common/odp_cunit_common.h
@@ -50,16 +50,12 @@ extern int odp_cunit_thread_exit(pthrd_arg *);
  * Initialize global resources needed by the test executable. Default
  * definition does ODP init / term (both global and local).
  * Test executables can override it by calling one of the register function
- * below (or by defining a strong version, but this is deprecated).
+ * below.
  * The functions are called at the very beginning and very end of the test
  * execution. Passing NULL to odp_cunit_register_global_init() and/or
  * odp_cunit_register_global_term() is legal and will simply prevent the
  * default (ODP init/term) to be done.
  */
-extern int tests_global_init(void);
-
-extern int tests_global_term(void);
-
 void odp_cunit_register_global_init(int (*func_init_ptr)(void));
 
 void odp_cunit_register_global_term(int (*func_term_ptr)(void));

--- a/test/validation/common/odp_cunit_common.h
+++ b/test/validation/common/odp_cunit_common.h
@@ -17,13 +17,6 @@
 
 #define MAX_WORKERS 32 /**< Maximum number of work threads */
 
-/**
- * Array of testsuites provided by a test application. Array must be terminated
- * by CU_SUITE_INFO_NULL and must be suitable to be used by
- * CU_register_suites().
- */
-extern CU_SuiteInfo odp_testsuites[];
-
 /* the function, called by module main(), to run the testsuites: */
 int odp_cunit_run(CU_SuiteInfo testsuites[]);
 

--- a/test/validation/crypto/crypto.c
+++ b/test/validation/crypto/crypto.c
@@ -23,7 +23,7 @@ static CU_SuiteInfo crypto_suites[] = {
 	CU_SUITE_INFO_NULL,
 };
 
-int tests_global_init(void)
+static int crypto_init(void)
 {
 	odp_pool_param_t params;
 	odp_pool_t pool;
@@ -60,7 +60,7 @@ int tests_global_init(void)
 	return 0;
 }
 
-int tests_global_term(void)
+static int crypto_term(void)
 {
 	odp_pool_t pool;
 	odp_queue_t out_queue;
@@ -96,5 +96,7 @@ int tests_global_term(void)
 
 int crypto_main(void)
 {
+	odp_cunit_register_global_init(crypto_init);
+	odp_cunit_register_global_term(crypto_term);
 	return odp_cunit_run(crypto_suites);
 }

--- a/test/validation/synchronizers/synchronizers.c
+++ b/test/validation/synchronizers/synchronizers.c
@@ -1052,7 +1052,7 @@ static int synchronizers_suite_init(void)
 	return 0;
 }
 
-int tests_global_init(void)
+static int synchronizers_init(void)
 {
 	uint32_t core_count, max_threads;
 	int ret = 0;
@@ -1210,5 +1210,6 @@ static CU_SuiteInfo synchronizers_suites[] = {
 
 int synchronizers_main(void)
 {
+	odp_cunit_register_global_init(synchronizers_init);
 	return odp_cunit_run(synchronizers_suites);
 }


### PR DESCRIPTION
Second iteration.

I removed the factorization of TESTS_ENVIRONMENT flags because I have not been able to find a proper way
 to include Makefile.inc between each other due to test/Makefile.inc having automake variable in it.

This becomes a much simpler pathset as it only add EXEEXT to all the tests TEST_ENVIRONMENTS so that scripts can automatically 
add the right binary extensions when calling built executables
